### PR TITLE
Add source support beyond 'ulb' and 'obs'

### DIFF
--- a/.dockeringore
+++ b/.dockeringore
@@ -1,0 +1,3 @@
+node_modules
+npm-debug.log
+Dockerfile

--- a/.dockeringore
+++ b/.dockeringore
@@ -1,3 +1,2 @@
 node_modules
 npm-debug.log
-Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM node:12
 
 RUN apt update
 RUN apt upgrade -y
+RUN apt install -y libxtst-dev libxss-dev libgconf2-dev libnss3-dev libasound2-dev
 
 WORKDIR /app
 
@@ -14,8 +15,6 @@ RUN npm install
 COPY . .
 
 RUN bower install --allow-root
-
-RUN apt install -y libxtst-dev libxss-dev libgconf2-dev libnss3-dev libasound2-dev
 
 VOLUME /root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,16 @@
-FROM node:12
+FROM node:6
 
-RUN apt update
-RUN apt upgrade -y
-RUN apt install -y libxtst-dev libxss-dev libgconf2-dev libnss3-dev libasound2-dev
+RUN apt update \
+ && apt upgrade -y \
+ && apt install -y libxtst-dev libxss-dev libgconf2-dev libnss3-dev libasound2-dev
 
 WORKDIR /app
 
 COPY package*.json ./
 
-RUN npm install -g bower
-RUN npm install -g gulp
-RUN npm install
+RUN npm install -g bower \
+ && npm install -g gulp \
+ && npm install
 
 COPY . .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,11 +11,10 @@ RUN npm install -g bower
 RUN npm install -g gulp
 RUN npm install
 
+COPY . .
 
 RUN bower install --allow-root
 
 RUN apt install -y libxtst-dev libxss-dev libgconf2-dev libnss3-dev libasound2-dev
-
-COPY . .
 
 CMD npm start

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,6 @@ RUN bower install --allow-root
 
 RUN apt install -y libxtst-dev libxss-dev libgconf2-dev libnss3-dev libasound2-dev
 
+VOLUME /root
+
 CMD npm start

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM node:12
+
+RUN apt update
+RUN apt upgrade -y
+
+WORKDIR /app
+
+COPY package*.json ./
+
+RUN npm install -g bower
+RUN npm install -g gulp
+RUN npm install
+
+
+RUN bower install --allow-root
+
+RUN apt install -y libxtst-dev libxss-dev libgconf2-dev libnss3-dev libasound2-dev
+
+COPY . .
+
+CMD npm start

--- a/makefile
+++ b/makefile
@@ -1,24 +1,33 @@
-.PHONY: build run attach stop
+.PHONY: build rebuild run attach stop
 
 IMAGE_LABEL := bw-local-dev
 VOLUME_LABEL := $(IMAGE_LABEL)-volume
 
 build:
-	docker build . -t bw-local-dev
+	# Builds image
+	docker build --tag bw-local-dev .
+
+rebuild:
+	# Re-builds image from scratch (takes a while!)
+	docker build --no-cache --tag bw-local-dev .
 
 run:
+	# Starts BTT-Writer in a container.  The user directory is in a volume.
 	if [ -z "$$DISPLAY" ]; then echo "ERROR: DISPLAY var not set."; exit 1; fi; \
 	docker run --rm --volume $(VOLUME_LABEL):/root --env DISPLAY="${DISPLAY}" -t $(IMAGE_LABEL)
 
 attach:
-	# Attaches to a running BW container
+	# Attaches to the running BW container
 	CONTAINER_ID=$$(docker ps --filter ancestor=$(IMAGE_LABEL) --format '{{.Names}}'); \
 	if [ -z "$$CONTAINER_ID" ]; then echo "ERROR: No running container found."; exit 1; fi; \
 	docker exec -it $$CONTAINER_ID /bin/bash
 
 stop:
-	# Attaches to a running BW container
+	# Stops the running BW container
 	CONTAINER_ID=$$(docker ps --filter ancestor=$(IMAGE_LABEL) --format '{{.Names}}'); \
 	if [ -z "$$CONTAINER_ID" ]; then echo "ERROR: No running container found."; exit 1; fi; \
 	docker stop $$CONTAINER_ID
 
+clean:
+	# Removes volume
+	docker volume rm $(VOLUME_LABEL)

--- a/makefile
+++ b/makefile
@@ -1,0 +1,8 @@
+.PHONY: build run
+
+build:
+	docker build . -t bw-local-dev
+
+run:
+	docker run --rm --env DISPLAY="${DISPLAY}" -t bw-local-dev
+

--- a/makefile
+++ b/makefile
@@ -1,8 +1,24 @@
-.PHONY: build run
+.PHONY: build run attach stop
+
+IMAGE_LABEL := bw-local-dev
+VOLUME_LABEL := $(IMAGE_LABEL)-volume
 
 build:
 	docker build . -t bw-local-dev
 
 run:
-	docker run --rm --env DISPLAY="${DISPLAY}" -t bw-local-dev
+	if [ -z "$$DISPLAY" ]; then echo "ERROR: DISPLAY var not set."; exit 1; fi; \
+	docker run --rm --volume $(VOLUME_LABEL):/root --env DISPLAY="${DISPLAY}" -t $(IMAGE_LABEL)
+
+attach:
+	# Attaches to a running BW container
+	CONTAINER_ID=$$(docker ps --filter ancestor=$(IMAGE_LABEL) --format '{{.Names}}'); \
+	if [ -z "$$CONTAINER_ID" ]; then echo "ERROR: No running container found."; exit 1; fi; \
+	docker exec -it $$CONTAINER_ID /bin/bash
+
+stop:
+	# Attaches to a running BW container
+	CONTAINER_ID=$$(docker ps --filter ancestor=$(IMAGE_LABEL) --format '{{.Names}}'); \
+	if [ -z "$$CONTAINER_ID" ]; then echo "ERROR: No running container found."; exit 1; fi; \
+	docker stop $$CONTAINER_ID
 

--- a/makefile
+++ b/makefile
@@ -1,7 +1,10 @@
-.PHONY: build rebuild run attach stop clean
+.PHONY: edit build rebuild run attach stop clean
 
 IMAGE_LABEL := bw-local-dev
 VOLUME_LABEL := $(IMAGE_LABEL)-volume
+
+edit:
+	$(EDITOR) makefile Dockerfile src/js/*.js src/views/*.html src/elements/**/*.html src/css/*.css
 
 build:
 	# Builds image
@@ -13,14 +16,16 @@ rebuild:
 
 run:
 	# Starts BTT-Writer in a container.  The user directory is in a volume.
+	# Run detached to prevent messing up the tty.
+	# (Use `make stop` to end the program early.)
 	if [ -z "$$DISPLAY" ]; then echo "ERROR: DISPLAY var not set."; exit 1; fi; \
-	docker run --rm --volume $(VOLUME_LABEL):/root --env DISPLAY="${DISPLAY}" -t $(IMAGE_LABEL)
+	docker run --detach --rm --volume $(VOLUME_LABEL):/root --env DISPLAY="${DISPLAY}" $(IMAGE_LABEL)
 
 attach:
 	# Attaches to the running BW container
 	CONTAINER_ID=$$(docker ps --filter ancestor=$(IMAGE_LABEL) --format '{{.Names}}'); \
 	if [ -z "$$CONTAINER_ID" ]; then echo "ERROR: No running container found."; exit 1; fi; \
-	docker exec -it $$CONTAINER_ID /bin/bash
+	docker exec --interactive --tty $$CONTAINER_ID /bin/bash
 
 stop:
 	# Stops the running BW container

--- a/makefile
+++ b/makefile
@@ -11,11 +11,11 @@ edit:
 
 build:
 	# Builds image
-	docker build --tag bw-local-dev .
+	docker build --tag . $(IMAGE_LABEL)
 
 rebuild:
 	# Re-builds image from scratch (takes a while!)
-	docker build --no-cache --tag bw-local-dev .
+	docker build --no-cache --tag $(IMAGE_LABEL) .
 
 run:
 	# Starts BTT-Writer in a container.  The user directory is in a volume.

--- a/makefile
+++ b/makefile
@@ -18,8 +18,9 @@ rebuild:
 	docker build --no-cache --tag $(IMAGE_LABEL) .
 
 run:
-	# Starts BTT-Writer in a container.  The user directory is in a volume.
-	# Runs detached to prevent messing up the tty.  (Use `make stop` to end if needed.)
+	# Starts BTT-Writer in a container. Volume persists user data.
+	# Runs detached to prevent messing up the tty.  Use 'make stop' to end if needed.
+	# If on WSL: $$DISPLAY should be set to your X display manager, e.g. '192.168.3.3:0.0'
 	test $(DISPLAY) # If blank, then $$DISPLAY is not set
 	test ! $(CONTAINER_ID) # If not blank, then container is already running
 	docker run --detach --rm --net=host \

--- a/makefile
+++ b/makefile
@@ -22,7 +22,10 @@ run:
 	# Runs detached to prevent messing up the tty.  (Use `make stop` to end if needed.)
 	test $(DISPLAY) # If blank, then $$DISPLAY is not set
 	test ! $(CONTAINER_ID) # If not blank, then container is already running
-	docker run --detach --rm --net=host --volume="${HOME}/.Xauthority:/root/.Xauthority:rw" --volume $(VOLUME_LABEL):/root --env DISPLAY="${DISPLAY}" $(IMAGE_LABEL)
+	docker run --detach --rm --net=host \
+	           --volume="${HOME}/.Xauthority:/root/.Xauthority:rw" \
+	           --volume $(VOLUME_LABEL):/root \
+	           --env DISPLAY="${DISPLAY}" $(IMAGE_LABEL)
 
 logs:
 	# Displays recent logs from running app

--- a/makefile
+++ b/makefile
@@ -4,6 +4,7 @@ IMAGE_LABEL := bw-local-dev
 VOLUME_LABEL := $(IMAGE_LABEL)-volume
 
 edit:
+	# Edits common files in your favorite editor
 	$(EDITOR) makefile Dockerfile src/js/*.js src/views/*.html src/elements/**/*.html src/css/*.css
 
 build:
@@ -20,6 +21,18 @@ run:
 	# (Use `make stop` to end the program early.)
 	if [ -z "$$DISPLAY" ]; then echo "ERROR: DISPLAY var not set."; exit 1; fi; \
 	docker run --detach --rm --volume $(VOLUME_LABEL):/root --env DISPLAY="${DISPLAY}" $(IMAGE_LABEL)
+
+logs:
+	# Displays recent logs from running app
+	CONTAINER_ID=$$(docker ps --filter ancestor=$(IMAGE_LABEL) --format '{{.Names}}'); \
+	if [ -z "$$CONTAINER_ID" ]; then echo "ERROR: No running container found."; exit 1; fi; \
+	docker logs $$CONTAINER_ID
+
+logs-follow:
+	# Displays and follows recent logs from running app
+	CONTAINER_ID=$$(docker ps --filter ancestor=$(IMAGE_LABEL) --format '{{.Names}}'); \
+	if [ -z "$$CONTAINER_ID" ]; then echo "ERROR: No running container found."; exit 1; fi; \
+	docker logs --follow $$CONTAINER_ID
 
 attach:
 	# Attaches to the running BW container

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-.PHONY: build rebuild run attach stop
+.PHONY: build rebuild run attach stop clean
 
 IMAGE_LABEL := bw-local-dev
 VOLUME_LABEL := $(IMAGE_LABEL)-volume

--- a/makefile
+++ b/makefile
@@ -45,7 +45,8 @@ stop:
 	docker stop $(CONTAINER_ID)
 
 test:
-	# Stops the running BW container
+	# Runs tests in the container
+	# TODO: Determine why tests sometimes fail -- timing issue?
 	test ! $(CONTAINER_ID) # If not blank, then container is already running
 	docker run --interactive --tty --rm $(IMAGE_LABEL) bash -c "gulp test"
 
@@ -55,4 +56,5 @@ clean:
 
 release:
 	# Creates executables
+	# TODO: Add support for building Windows, etc. -- see .travis.yml
 	docker run --rm --volume $(RELEASE_DIR):/app/release $(IMAGE_LABEL) bash -c "gulp build --linux && gulp release"

--- a/makefile
+++ b/makefile
@@ -1,8 +1,9 @@
-.PHONY: edit build rebuild run logs logs-follow attach stop clean
+.PHONY: edit build rebuild run logs logs-follow attach stop test clean release
 
 IMAGE_LABEL := bw-local-dev
 VOLUME_LABEL := $(IMAGE_LABEL)-volume
 CONTAINER_ID := $(shell docker ps --filter ancestor=$(IMAGE_LABEL) --format '{{.Names}}')
+RELEASE_DIR := $(HOME)/btt-writer-release
 
 edit:
 	# Edits common files in your favorite editor
@@ -43,6 +44,15 @@ stop:
 	test $(CONTAINER_ID) # If blank, then container isn't running
 	docker stop $(CONTAINER_ID)
 
+test:
+	# Stops the running BW container
+	test ! $(CONTAINER_ID) # If not blank, then container is already running
+	docker run --interactive --tty --rm $(IMAGE_LABEL) bash -c "gulp test"
+
 clean:
 	# Removes volume
 	docker volume rm $(VOLUME_LABEL)
+
+release:
+	# Creates executables
+	docker run --rm --volume $(RELEASE_DIR):/app/release $(IMAGE_LABEL) bash -c "gulp build --linux && gulp release"

--- a/makefile
+++ b/makefile
@@ -22,7 +22,7 @@ run:
 	# Runs detached to prevent messing up the tty.  (Use `make stop` to end if needed.)
 	test $(DISPLAY) # If blank, then $$DISPLAY is not set
 	test ! $(CONTAINER_ID) # If not blank, then container is already running
-	docker run --detach --rm --volume $(VOLUME_LABEL):/root --env DISPLAY="${DISPLAY}" $(IMAGE_LABEL)
+	docker run --detach --rm --net=host --volume="${HOME}/.Xauthority:/root/.Xauthority:rw" --volume $(VOLUME_LABEL):/root --env DISPLAY="${DISPLAY}" $(IMAGE_LABEL)
 
 logs:
 	# Displays recent logs from running app

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "BTT-Writer",
   "productName": "BTT-Writer",
-  "version": "1.0.3",
-  "build": "4",
+  "version": "1.0.5",
+  "build": "5",
   "description": "A utility for translating the Bible and biblical content into any language. (from tS 11.1.0)",
   "keywords": [],
   "homepage": "https://github.com/wycliffeassociates/ts-desktop",

--- a/src/js/database.js
+++ b/src/js/database.js
@@ -173,34 +173,22 @@ function DataManager(db, resourceDir, sourceDir) {
                     item.errmsg = errmessage;
                 })
                 .then(function () {
-                    // if (resource === "ulb" || resource === "obs") {
-                        return mythis.downloadContainer(language, project, "tn")
-                            .catch(function () {
-                                return true;
-                            });
-                    // } else {
-                    //     return Promise.resolve(true);
-                    // }
+                    return mythis.downloadContainer(language, project, "tn")
+                        .catch(function () {
+                            return true;
+                        });
                 })
                 .then(function () {
-                    // if (resource === "ulb" || resource === "obs") {
-                        return mythis.downloadContainer(language, project, "tq")
-                            .catch(function () {
-                                return true;
-                            });
-                    // } else {
-                    //     return Promise.resolve(true);
-                    // }
+                    return mythis.downloadContainer(language, project, "tq")
+                        .catch(function () {
+                            return true;
+                        });
                 })
                 .then(function () {
-                    // if (resource === "ulb") {
-                        return mythis.downloadContainer(language, project, "udb")
-                            .catch(function () {
-                                return true;
-                            });
-                    // } else {
-                    //     return Promise.resolve(true);
-                    // }
+                    return mythis.downloadContainer(language, project, "udb")
+                        .catch(function () {
+                            return true;
+                        });
                 })
                 .then(function () {
                     return item;
@@ -247,25 +235,13 @@ function DataManager(db, resourceDir, sourceDir) {
                     }
                 })
                 .then(function () {
-                    // if (resource === "ulb" || resource === "obs") {
-                        return mythis.activateContainer(language, project, "tn");
-                    // } else {
-                    //     return Promise.resolve(true);
-                    // }
+                    return mythis.activateContainer(language, project, "tn");
                 })
                 .then(function () {
-                    // if (resource === "ulb" || resource === "obs") {
-                        return mythis.activateContainer(language, project, "tq");
-                    // } else {
-                    //     return Promise.resolve(true);
-                    // }
+                    return mythis.activateContainer(language, project, "tq");
                 })
                 .then(function () {
-                    // if (resource === "ulb") {
-                        return mythis.activateContainer(language, project, "udb");
-                    // } else {
-                    //     return Promise.resolve(true);
-                    // }
+                    return mythis.activateContainer(language, project, "udb");
                 });
         },
 
@@ -373,49 +349,37 @@ function DataManager(db, resourceDir, sourceDir) {
         getSourceUdb: function (source) {
             var container = source.language_id + "_" + source.project_id + "_udb";
 
-            // if (source.resource_id === "ulb") {
-                return this.extractContainer(container);
-            // } else {
-            //     return [];
-            // }
+            return this.extractContainer(container);
         },
 
         getSourceNotes: function (source) {
             var mythis = this;
             var container = source.language_id + "_" + source.project_id + "_tn";
 
-            // if (source.resource_id === "ulb" || source.resource_id === "obs") {
-                var frames = this.extractContainer(container);
+            var frames = this.extractContainer(container);
 
-                frames.forEach(function (item) {
-                    if (item.content) {
-                        item.content = mythis.parseHelps(item.content);
-                    }
-                });
+            frames.forEach(function (item) {
+                if (item.content) {
+                    item.content = mythis.parseHelps(item.content);
+                }
+            });
 
-                return frames;
-            // } else {
-            //     return [];
-            // }
+            return frames;
         },
 
         getSourceQuestions: function (source) {
             var mythis = this;
             var container = source.language_id + "_" + source.project_id + "_tq";
 
-            // if (source.resource_id === "ulb" || source.resource_id === "obs") {
-                var frames = this.extractContainer(container);
+            var frames = this.extractContainer(container);
 
-                frames.forEach(function (item) {
-                    if (item.content) {
-                        item.content = mythis.parseHelps(item.content);
-                    }
-                });
+            frames.forEach(function (item) {
+                if (item.content) {
+                    item.content = mythis.parseHelps(item.content);
+                }
+            });
 
-                return frames;
-            // } else {
-            //     return [];
-            // }
+            return frames;
         },
 
         getSourceWords: function (source) {

--- a/src/js/database.js
+++ b/src/js/database.js
@@ -173,34 +173,34 @@ function DataManager(db, resourceDir, sourceDir) {
                     item.errmsg = errmessage;
                 })
                 .then(function () {
-                    if (resource === "ulb" || resource === "obs") {
+                    // if (resource === "ulb" || resource === "obs") {
                         return mythis.downloadContainer(language, project, "tn")
                             .catch(function () {
                                 return true;
                             });
-                    } else {
-                        return Promise.resolve(true);
-                    }
+                    // } else {
+                    //     return Promise.resolve(true);
+                    // }
                 })
                 .then(function () {
-                    if (resource === "ulb" || resource === "obs") {
+                    // if (resource === "ulb" || resource === "obs") {
                         return mythis.downloadContainer(language, project, "tq")
                             .catch(function () {
                                 return true;
                             });
-                    } else {
-                        return Promise.resolve(true);
-                    }
+                    // } else {
+                    //     return Promise.resolve(true);
+                    // }
                 })
                 .then(function () {
-                    if (resource === "ulb") {
+                    // if (resource === "ulb") {
                         return mythis.downloadContainer(language, project, "udb")
                             .catch(function () {
                                 return true;
                             });
-                    } else {
-                        return Promise.resolve(true);
-                    }
+                    // } else {
+                    //     return Promise.resolve(true);
+                    // }
                 })
                 .then(function () {
                     return item;
@@ -247,25 +247,25 @@ function DataManager(db, resourceDir, sourceDir) {
                     }
                 })
                 .then(function () {
-                    if (resource === "ulb" || resource === "obs") {
+                    // if (resource === "ulb" || resource === "obs") {
                         return mythis.activateContainer(language, project, "tn");
-                    } else {
-                        return Promise.resolve(true);
-                    }
+                    // } else {
+                    //     return Promise.resolve(true);
+                    // }
                 })
                 .then(function () {
-                    if (resource === "ulb" || resource === "obs") {
+                    // if (resource === "ulb" || resource === "obs") {
                         return mythis.activateContainer(language, project, "tq");
-                    } else {
-                        return Promise.resolve(true);
-                    }
+                    // } else {
+                    //     return Promise.resolve(true);
+                    // }
                 })
                 .then(function () {
-                    if (resource === "ulb") {
+                    // if (resource === "ulb") {
                         return mythis.activateContainer(language, project, "udb");
-                    } else {
-                        return Promise.resolve(true);
-                    }
+                    // } else {
+                    //     return Promise.resolve(true);
+                    // }
                 });
         },
 
@@ -373,18 +373,18 @@ function DataManager(db, resourceDir, sourceDir) {
         getSourceUdb: function (source) {
             var container = source.language_id + "_" + source.project_id + "_udb";
 
-            if (source.resource_id === "ulb") {
+            // if (source.resource_id === "ulb") {
                 return this.extractContainer(container);
-            } else {
-                return [];
-            }
+            // } else {
+            //     return [];
+            // }
         },
 
         getSourceNotes: function (source) {
             var mythis = this;
             var container = source.language_id + "_" + source.project_id + "_tn";
 
-            if (source.resource_id === "ulb" || source.resource_id === "obs") {
+            // if (source.resource_id === "ulb" || source.resource_id === "obs") {
                 var frames = this.extractContainer(container);
 
                 frames.forEach(function (item) {
@@ -394,16 +394,16 @@ function DataManager(db, resourceDir, sourceDir) {
                 });
 
                 return frames;
-            } else {
-                return [];
-            }
+            // } else {
+            //     return [];
+            // }
         },
 
         getSourceQuestions: function (source) {
             var mythis = this;
             var container = source.language_id + "_" + source.project_id + "_tq";
 
-            if (source.resource_id === "ulb" || source.resource_id === "obs") {
+            // if (source.resource_id === "ulb" || source.resource_id === "obs") {
                 var frames = this.extractContainer(container);
 
                 frames.forEach(function (item) {
@@ -413,9 +413,9 @@ function DataManager(db, resourceDir, sourceDir) {
                 });
 
                 return frames;
-            } else {
-                return [];
-            }
+            // } else {
+            //     return [];
+            // }
         },
 
         getSourceWords: function (source) {

--- a/win64_installer.iss
+++ b/win64_installer.iss
@@ -2,8 +2,8 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 
 #define MyAppName "BTT-Writer"
-#define Version "1.0.3"
-#define Build "4"
+#define Version "1.0.5"
+#define Build "5"
 #define MyAppPublisher "Wycliffe Associates"
 #define MyAppURL "https://writer.bibletranslationtools.org"
 #define MyAppExeName "BTT-Writer.exe"


### PR DESCRIPTION
Changes in this pull request:
- Remove restriction so that any source can have resources, not just "ulb" and "obs"
- Add support for developing using a Docker container
- Update version to 1.0.5 b5