### PR TITLE
Replace Buffer() deprecation

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
     "yargs": "4.8.1"
   },
   "engines": {
-    "electron": "12.0.0"
+    "electron": "12.0.0",
+    "node": ">=14.0.0 <=14.16.0"
   },
   "scripts": {
     "start": "electron src/js/main.js --no-sandbox",

--- a/src/js/exporter.js
+++ b/src/js/exporter.js
@@ -100,7 +100,7 @@ function ExportManager(configurator, git) {
                                     // TODO: we need to get the chapter reference and insert it here
                                     chapterContent += '////\n';
                                     //console.log('chapter ' + currentChapter, chapterContent);
-                                    zip.append(new Buffer(chapterContent), {name: currentChapter + '.md'});
+                                    zip.append(Buffer.from(chapterContent), {name: currentChapter + '.md'});
                                 }
                                 currentChapter = frame.chunkmeta.chapter;
                                 chapterContent = '';
@@ -133,7 +133,7 @@ function ExportManager(configurator, git) {
                         if(chapterContent !== '' && numFinishedFrames > 0) {
                             // TODO: we need to get the chapter reference and insert it here
                             chapterContent += '////\n';
-                            zip.append(new Buffer(chapterContent), {name: currentChapter + '.md'});
+                            zip.append(Buffer.from(chapterContent), {name: currentChapter + '.md'});
                         }
                         zip.finalize();
                         resolve(true);

--- a/src/js/lib/db.js
+++ b/src/js/lib/db.js
@@ -13,7 +13,7 @@ function Db (schemaPath, dbPath) {
 
     function saveDB (sql) {
         let data = sql.export();
-        let buffer = new Buffer(data);
+        let buffer = Buffer.from(data);
 
         mkdirp.sync(dbDirPath, '0755');
         fs.writeFileSync(dbFilePath, buffer);


### PR DESCRIPTION
Minor update:
- use ` Buffer.from() ` instead of deprecated ` new Buffer() ` - https://nodejs.org/en/docs/guides/buffer-constructor-deprecation/
- add `"node"` to engine in package.json - https://www.electronjs.org/releases/stable?page=2#12.0.0