### PR TITLE
Fix Import Project File & USFM

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -285,7 +285,7 @@ ipcMain.on('save-as', function (event, arg) {
 ipcMain.on('open-file', function (event, arg) {
     dialog.showOpenDialog(mainWindow, arg.options)
         .then(function (value) {
-            event.returnValue = value.paths || value.bookmarks || false;
+            event.returnValue = value.filePaths || value.bookmarks || false;
         });
 });
 


### PR DESCRIPTION
The return value of showOpenDialog should be `filePaths`, not `paths`

https://www.electronjs.org/docs/api/dialog#dialogshowopendialogbrowserwindow-options