### PR TITLE
use ubuntu 18.04 for builds to fix wine

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
   # This workflow contains a single job called "build"
   build:
     # The type of runner that the job will run on
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -30,8 +30,8 @@ jobs:
         run: ./.github/scripts/build.sh
 
       #upload builds to AWS nightlybuilds
-      - name: set s3 destination_dir for release or dev for install4j updates to work
-        run: echo "CURRENT_S3_DESTINATION=$CI_REPOSITORY_OWNER/$CI_REPOSITORY_NAME/$CI_REF_NAME_SLUG" >> $GITHUB_ENV
+      - name: set s3 destination_dir for nightly-builds
+        run: echo "CURRENT_S3_DESTINATION=$CI_REPOSITORY_OWNER/$CI_REPOSITORY_NAME/$CI_REF_NAME_SLUG/$CI_RUN_NUMBER" >> $GITHUB_ENV
       - name: Upload file to bucket
         uses: shallwefootball/s3-upload-action@v1.1.3
         with:


### PR DESCRIPTION
Fixes build.

Changes in this pull request:
- Build uses Ubuntu 18.04
- artifacts pushed to run numbers for cleanliness in the nightly build listing