### PR TITLE
Direct user to server account creation page

### DIFF
--- a/src/config/user-setting.json
+++ b/src/config/user-setting.json
@@ -143,13 +143,15 @@
                 "name": "WACS", 
                 "dataserver": "https://wacs.bibletranslationtools.org", 
                 "mediaserver": "https://api.bibletranslationtools.org", 
-                "readerserver": "http://read.bibletranslationtools.org/u"
+                "readerserver": "http://read.bibletranslationtools.org/u",
+                "createaccounturl": "https://content.bibletranslationtools.org/user/sign_up"
             },
             {
                 "name": "DCS",  
                 "dataserver": "https://git.door43.org",
                 "mediaserver": "https://api.unfoldingword.org", 
-                "readerserver": "https://door43.org/u" 
+                "readerserver": "https://door43.org/u",
+                "createaccounturl": "https://git.door43.org/user/sign_up" 
             }
         ],
         "group": "advanced",
@@ -179,6 +181,15 @@
         "mainText": "Reader Server",
         "value": "http://read.bibletranslationtools.org/u",
         "default": "http://read.bibletranslationtools.org/u",
+        "group": "advanced",
+        "enabled": true,
+        "visible": true
+    },
+    {
+        "name": "createaccounturl",
+        "mainText": "Create Account URL",
+        "value": "https://content.bibletranslationtools.org/user/sign_up",
+        "default": "https://content.bibletranslationtools.org/user/sign_up",
         "group": "advanced",
         "enabled": true,
         "visible": true

--- a/src/elements/ts-profile/ts-options-menu.html
+++ b/src/elements/ts-profile/ts-options-menu.html
@@ -92,8 +92,10 @@
         },
 
         create: function () {
-            this.set('newinfo', {});
-            this.set('selected', 2);
+            // this.set('newinfo', {});
+            // this.set('selected', 2);
+            console.log("Clickaroo!");
+            require("electron").shell.openExternal("https://www.example.com");
         },
 
         local: function () {

--- a/src/elements/ts-profile/ts-options-menu.html
+++ b/src/elements/ts-profile/ts-options-menu.html
@@ -92,10 +92,12 @@
         },
 
         create: function () {
+            // To restore the original behavior where this opens the
+            // "Create Account" form, uncomment the next two lines:
             // this.set('newinfo', {});
             // this.set('selected', 2);
-            console.log("Clickaroo!");
-            require("electron").shell.openExternal("https://www.example.com");
+            var createaccounturl = App.configurator.getUserSetting('createaccounturl');
+            require("electron").shell.openExternal(createaccounturl);
         },
 
         local: function () {

--- a/src/elements/ts-settings/ts-settings.html
+++ b/src/elements/ts-settings/ts-settings.html
@@ -297,6 +297,7 @@
                 App.configurator.setUserSetting("dataserver", value.dataserver);
                 App.configurator.setUserSetting("mediaserver", value.mediaserver);
                 App.configurator.setUserSetting("readerserver", value.readerserver);
+                App.configurator.setUserSetting("createaccounturl", value.createaccounturl);
                 this.set('settings', App.configurator.refreshUserSetting());
                 this.saveSettings();
                 // Lgout user.


### PR DESCRIPTION
This PR changes what happens when the user clicks on the "Create Account" button on the profile page.  It now opens the user's browser to the account creation page of WACS or DCS.  The URL is customizable in settings.