### PR TITLE
Fix: Open Developer Tools

### DIFF
--- a/src/js/academybootstrap.js
+++ b/src/js/academybootstrap.js
@@ -105,7 +105,7 @@ process.stdout.write = console.log.bind(console);
         },
 
         showDevTools: function () {
-            require('electron').remote.getCurrentWindow().toggleDevTools();
+            this.ipc.send('show-devtools');
         },
 
         utils: utils,

--- a/src/js/bootstrap.js
+++ b/src/js/bootstrap.js
@@ -204,7 +204,7 @@ process.stdout.write = console.log.bind(console);
         },
 
         showDevTools: function () {
-            require('electron').remote.getCurrentWindow().toggleDevTools();
+            this.ipc.send('show-devtools');
         },
 
         utils: utils,

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -324,6 +324,10 @@ ipcMain.on('theme-loaded', (event, theme) => {
     nativeTheme.themeSource = theme.toLowerCase();
 });
 
+ipcMain.on('show-devtools', () => {
+    BrowserWindow.getFocusedWindow().webContents.openDevTools()
+});
+
 app.on('ready', function () {
     createAppMenus();
     createMainSplash();

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -325,7 +325,7 @@ ipcMain.on('theme-loaded', (event, theme) => {
 });
 
 ipcMain.on('show-devtools', () => {
-    BrowserWindow.getFocusedWindow().webContents.openDevTools()
+    BrowserWindow.getFocusedWindow().webContents.openDevTools();
 });
 
 app.on('ready', function () {


### PR DESCRIPTION
Fixes issue #100
electron "remote" module API is deprecated, thus causing the error when trying to open the developer tools. This PR uses the recommended approach by sending an `ipc` message to the main process and let it open the devtools
