### PR TITLE
Better handling corrupt projects

### DIFF
--- a/src/elements/ts-main/ts-dashboard.html
+++ b/src/elements/ts-main/ts-dashboard.html
@@ -518,7 +518,7 @@
 
           setTimeout(function() {
               return App.exportManager.autoBackupTranslation(projectmeta)
-                  .then(function (result) {
+                  .then(function () {
                       return App.projectsManager.deleteTargetTranslation(projectmeta)
                   })
                   .then(function() {
@@ -534,10 +534,34 @@
                   .then(function () {
                       mythis.showMessage('Project Deleted', 'Your project has been successfully deleted.');
                   })
-                  .catch(function (err) {
-                      mythis.showErrorMessage('Delete Failed', `An error occurred while trying to delete your project. (${err})`, err);
+                  .catch(function () {
+                      mythis.deleteCorruptProject(projectmeta);
                   })
           }, 500);
+      },
+
+      deleteCorruptProject: function (projectmeta) {
+          var mythis = this;
+          App.projectsManager.backupProject(projectmeta.projectDir)
+              .then(function () {
+                  return App.projectsManager.deleteTargetTranslation(projectmeta)
+              })
+              .then(function() {
+                  App.projectsManager.unsetValues(projectmeta.unique_id);
+
+                  var list = mythis.projectlist;
+                  var newlist = list.filter(function (item) {
+                      return item.unique_id !== projectmeta.unique_id;
+                  });
+
+                  return mythis.sortProjects(newlist);
+              })
+              .then(function () {
+                  mythis.showMessage('Project Deleted', 'Your project has been successfully deleted.');
+              })
+              .catch(function (err) {
+                  mythis.showErrorMessage('Delete Failed', `An error occurred while trying to delete your project. (${err})`, err);
+              })
       },
 
       changeProject: function (event, data) {
@@ -1231,14 +1255,16 @@
           for (var i = 0; i < list.length; i++) {
               var proj = list[i].project.id;
 
-              for (var j = 0; j < list[i].source_translations.length; j++) {
-                  var lang = list[i].source_translations[j].language_id;
-                  var res = list[i].source_translations[j].resource_id;
-                  var string = lang + "_" + proj + "_" + res;
-                  if (!strings[string]) {
-                      strings[string] = true;
-                      var open = App.dataManager.activateProjectContainers(lang, proj, res);
-                      promises.push(open);
+              if ('source_translations' in list[i]) {
+                  for (var j = 0; j < list[i].source_translations.length; j++) {
+                      var lang = list[i].source_translations[j].language_id;
+                      var res = list[i].source_translations[j].resource_id;
+                      var string = lang + "_" + proj + "_" + res;
+                      if (!strings[string]) {
+                          strings[string] = true;
+                          var open = App.dataManager.activateProjectContainers(lang, proj, res);
+                          promises.push(open);
+                      }
                   }
               }
           }
@@ -1392,7 +1418,7 @@
                       return App.projectsManager.loadTargetTranslationsList()
                           .then(function (list) {
                               App.ipc.send('loading-status', 'Opening resource containers...');
-                              return mythis.checkAllContainers(list);
+                              return mythis.checkAllContainers(_.compact(list));
                           })
                           .then(function (list) {
                               App.ipc.send('loading-status', 'Updating Project List...');

--- a/src/js/lib/utils.js
+++ b/src/js/lib/utils.js
@@ -491,6 +491,18 @@ var utils = {
 
     fileExists: function (file) {
         return utils.fs.stat(file).then(utils.ret(true)).catch(utils.ret(false));
+    },
+
+    getDateAndTime: function () {
+        var date = new Date();
+        var year = date.getFullYear();
+        var month = `${date.getMonth() + 1}`.padStart(2, '0');
+        var day = `${date.getDate()}`.padStart(2, '0');
+        var hours = `${date.getHours()}`.padStart(2, '0');
+        var minutes = `${date.getMinutes()}`.padStart(2, '0');
+        var seconds = `${date.getSeconds()}`.padStart(2, '0');
+
+        return `${year}${month}${day}${hours}${minutes}${seconds}`;
     }
 };
 

--- a/src/js/lib/utils.js
+++ b/src/js/lib/utils.js
@@ -487,6 +487,10 @@ var utils = {
             }
         }
         return paths;
+    },
+
+    fileExists: function (file) {
+        return utils.fs.stat(file).then(utils.ret(true)).catch(utils.ret(false));
     }
 };
 

--- a/src/js/projects.js
+++ b/src/js/projects.js
@@ -3,6 +3,7 @@
 var _ = require('lodash'),
     path = require('path'),
     utils = require('../js/lib/utils'),
+    archiver = require('archiver'),
     fs = require('fs'),
     trash = require('trash');
 
@@ -228,15 +229,17 @@ function ProjectsManager(dataManager, configurator, reporter, git, migrator) {
 
                 var sources = [];
 
-                for (var j = 0; j < manifest.source_translations.length; j++) {
-                    var details = dataManager.getSourceDetails(manifest.project.id, manifest.source_translations[j].language_id, manifest.source_translations[j].resource_id);
+                if ('source_translations' in manifest) {
+                    for (var j = 0; j < manifest.source_translations.length; j++) {
+                        var details = dataManager.getSourceDetails(manifest.project.id, manifest.source_translations[j].language_id, manifest.source_translations[j].resource_id);
 
-                    if (manifest.source_translations[j].resource_id === "udb" && manifest.resource.id !== "udb") {
-                        details = false;
-                    }
+                        if (manifest.source_translations[j].resource_id === "udb" && manifest.resource.id !== "udb") {
+                            details = false;
+                        }
 
-                    if (details) {
-                        sources.push(details);
+                        if (details) {
+                            sources.push(details);
+                        }
                     }
                 }
 
@@ -474,6 +477,7 @@ function ProjectsManager(dataManager, configurator, reporter, git, migrator) {
         },
 
         loadTargetTranslationsList: function () {
+            const mythis = this;
             var paths = utils.makeProjectPaths.bind(utils, targetDir);
             return this.loadProjectsList()
                 .then(map(paths))
@@ -489,9 +493,21 @@ function ProjectsManager(dataManager, configurator, reporter, git, migrator) {
                         return test;
                     })
                 })
-                .then(map(read))
+                .then(map(function(manifestFile) {
+                    const projectDir = path.dirname(manifestFile);
+                    return read(manifestFile)
+                        .then(fromJSON)
+                        .then(function (meta) {
+                            meta.projectDir = projectDir;
+                            return meta;
+                        })
+                        .catch(function (err) {
+                            reporter.logError(`Error in ${manifestFile}`, err);
+
+                            mythis.backupProject(projectDir);
+                        });
+                }))
                 .then(Promise.all.bind(Promise))
-                .then(map(fromJSON))
         },
 
         migrateTargetTranslationsList: function () {
@@ -581,19 +597,49 @@ function ProjectsManager(dataManager, configurator, reporter, git, migrator) {
 
         deleteTargetTranslation: function (meta) {
             var paths = utils.makeProjectPaths(targetDir, meta);
+            let projectDir = paths.projectDir;
 
-            return utils.fs.stat(paths.projectDir).then(utils.ret(true)).catch(utils.ret(false))
+            return utils.fileExists(projectDir)
+                .then(function (exists) {
+                    if (!exists) {
+                        projectDir = meta.projectDir;
+                        return utils.fileExists(projectDir)
+                    }
+                    return true;
+                })
                 .then(function (exists) {
                     if (exists) {
-                        return trash([paths.projectDir]);
+                        return trash([projectDir]);
                     } else {
-                        throw "Project file does not exist";
+                        throw "Project directory does not exist";
                     }
                 })
                 .catch(function (err) {
                     throw err || "Unable to delete file at this time.";
                 });
-        }
+        },
+
+        backupProject: function (projectDir) {
+            const projectName = path.basename(projectDir);
+            var autoBackupDir = configurator.getUserPath('datalocation', 'automatic_backups');
+            var filePath = path.join(autoBackupDir, `${projectName}.zip`);
+
+            return utils.fileExists(projectDir)
+                .then(function (exists) {
+                    if (!exists) {
+                        throw "Project directory does not exist";
+                    }
+                })
+                .then(function () {
+                    var output = fs.createWriteStream(filePath);
+                    var archive = archiver.create('zip');
+                    archive.pipe(output);
+                    archive.directory(projectDir, projectName + "/");
+                    return archive.finalize().then(function () {
+                        return filePath;
+                    });
+                });
+            }
     };
 }
 

--- a/src/js/projects.js
+++ b/src/js/projects.js
@@ -622,7 +622,7 @@ function ProjectsManager(dataManager, configurator, reporter, git, migrator) {
         backupProject: function (projectDir) {
             const projectName = path.basename(projectDir);
             var autoBackupDir = configurator.getUserPath('datalocation', 'automatic_backups');
-            var filePath = path.join(autoBackupDir, `${projectName}.zip`);
+            var filePath = path.join(autoBackupDir, `${projectName}_${utils.getDateAndTime()}.zip`);
 
             return utils.fileExists(projectDir)
                 .then(function (exists) {
@@ -639,7 +639,7 @@ function ProjectsManager(dataManager, configurator, reporter, git, migrator) {
                         return filePath;
                     });
                 });
-            }
+        }
     };
 }
 


### PR DESCRIPTION
Fixes #143, #152  .

Changes in this pull request:
- Properly handle and backup projects, manifest of which could not be parsed
- Correctly load old version projects (those that do not have source_translations field in manifest)
- Allow to backup and delete projects that cannot be deleted normally