### PR TITLE
Render poetry markers in chunk previews and printed PDFs

### DIFF
--- a/src/css/print.css
+++ b/src/css/print.css
@@ -56,10 +56,10 @@ h1, h2 {
     display: none;
 }
 
-@page { 
-    @top-center { 
-        content: string(title) 
-    } 
+@page {
+    @top-center {
+        content: string(title)
+    }
 }
 
 #startnum {
@@ -82,6 +82,30 @@ sup {
 a {
     text-decoration: none;
     color: black;
+}
+
+.poetry1 {
+    padding-left: 20px;
+}
+
+.poetry2 {
+    padding-left: 40px;
+}
+
+.poetry3 {
+    padding-left: 60px;
+}
+
+.poetry4 {
+    padding-left: 80px;
+}
+
+.poetry5 {
+    padding-left: 100px;
+}
+
+.poetry6 {
+    padding-left: 120px;
 }
 
 

--- a/src/elements/ts-print/ts-print.html
+++ b/src/elements/ts-print/ts-print.html
@@ -104,6 +104,30 @@
             direction: rtl;
         }
 
+        .poetry1 {
+            padding-left: 20px;
+        }
+
+        .poetry2 {
+            padding-left: 40px;
+        }
+
+        .poetry3 {
+            padding-left: 60px;
+        }
+
+        .poetry4 {
+            padding-left: 80px;
+        }
+
+        .poetry5 {
+            padding-left: 100px;
+        }
+
+        .poetry6 {
+            padding-left: 120px;
+        }
+
     </style>
 
     <template>
@@ -183,15 +207,15 @@
         },
 
         rendertext: function () {
-            var chunks = this.currentproject.chunks;
-            var options = this.currentproject.printoptions;
-            var book = chunks[0].transcontent || chunks[0].srccontent;
-            var resource = chunks[0].projectmeta.target_language.name + ": " + chunks[0].projectmeta.resource.name;
-            var pagetitle = chunks[0].projectmeta.target_language.name + " - " + book;
+            const chunks = this.currentproject.chunks;
+            const options = this.currentproject.printoptions;
+            const book = chunks[0].transcontent || chunks[0].srccontent;
+            const resource = chunks[0].projectmeta.target_language.name + ": " + chunks[0].projectmeta.resource.name;
+            const pagetitle = chunks[0].projectmeta.target_language.name + " - " + book;
 
             this.$.licenseholder.markdown = App.printManager.getLicense("LICENSE.md");
-            this.$.resource.innerHTML = resource;
-            this.$.title.innerHTML = book;
+            this.$.resource.textContent = resource;
+            this.$.title.textContent = book;
             this.$.textholder.innerHTML = App.renderer.renderPrintPreview(chunks, options, pagetitle);
         },
 
@@ -207,9 +231,9 @@
 
         load: function () {
             if (this.route === "preview") {
-                var links = this.getElementsByTagName('a');
+                const links = this.getElementsByTagName('a');
 
-                for (var i = 0; i < links.length; i++) {
+                for (let i = 0; i < links.length; i++) {
                     links[i].addEventListener('click', this.externalClick);
                 }
 
@@ -218,15 +242,15 @@
         },
 
         externalClick: function (event) {
-            var shell = require('electron').shell;
+            const shell = require('electron').shell;
 
             event.preventDefault();
             shell.openExternal(this.href);
         },
 
         goback: function () {
-            var mythis = this;
-            var backto = this.backto;
+            const mythis = this;
+            const backto = this.backto;
 
             mythis.$.content.scrollTop = 0;
             mythis.set('route', backto);
@@ -242,11 +266,19 @@
         },
 
         print: function () {
-            var mythis = this;
-            var name = this.currentproject.projectmeta.unique_id;
-            var defaultPath = App.configurator.getUserPath('datalocation', name);
-            var direction = this.currentproject.projectmeta.target_language.direction;
-            var filePath = App.ipc.sendSync('save-as', {options: {defaultPath: defaultPath, filters: [{name: 'PDF Files', extensions: ['pdf']}]}});
+            const mythis = this;
+            const name = this.currentproject.projectmeta.unique_id;
+            const defaultPath = App.configurator.getUserPath('datalocation', name);
+            const direction = this.currentproject.projectmeta.target_language.direction;
+            const filePath = App.ipc.sendSync('save-as', {
+                options: {
+                    defaultPath: defaultPath,
+                    filters: [{
+                        name: 'PDF Files',
+                        extensions: ['pdf']
+                    }]
+                }
+            });
             if (!filePath) {
                 return;
             }
@@ -256,10 +288,10 @@
             mythis.set('options.loading', true);
             mythis.fire('iron-signal', {name: 'openloading'});
 
-            var resource = mythis.$.resource.innerHTML;
-            var title = mythis.$.title.innerHTML;
-            var license = mythis.$.license.innerHTML;
-            var body = mythis.$.textholder.innerHTML;
+            const resource = mythis.$.resource.innerHTML;
+            const title = mythis.$.title.innerHTML;
+            const license = mythis.$.license.innerHTML;
+            const body = mythis.$.textholder.innerHTML;
 
             setTimeout(function() {
                 return App.printManager.savePdf(resource, title, license, body, filePath, direction)
@@ -270,7 +302,7 @@
                         mythis.goback();
                     })
                     .catch(function (err) {
-                        var errmessage = mythis.translate("save_project_error");
+                        let errmessage = mythis.translate("save_project_error");
                         if(err !== null) {
                             errmessage = err;
                         }
@@ -286,7 +318,7 @@
         },
 
         princeLink: function () {
-            var translated = this.translate("pdf_generated_by", '<a href="https://www.princexml.com/">Prince</a>');
+            const translated = this.translate("pdf_generated_by", '<a href="https://www.princexml.com/">Prince</a>');
             this.$.attrib.innerHTML = `(${translated})`;
         },
 

--- a/src/elements/ts-translate/ts-target/ts-target-review.html
+++ b/src/elements/ts-translate/ts-target/ts-target-review.html
@@ -98,6 +98,30 @@
             display: none;
         }
 
+        .poetry1 {
+            padding-left: 20px;
+        }
+
+        .poetry2 {
+            padding-left: 40px;
+        }
+
+        .poetry3 {
+            padding-left: 60px;
+        }
+
+        .poetry4 {
+            padding-left: 80px;
+        }
+
+        .poetry5 {
+            padding-left: 100px;
+        }
+
+        .poetry6 {
+            padding-left: 120px;
+        }
+
 	</style>
 
 	<template>

--- a/src/elements/ts-translate/ts-target/ts-target-view.html
+++ b/src/elements/ts-translate/ts-target/ts-target-view.html
@@ -77,6 +77,30 @@
             display: flex;
         }
 
+        .poetry1 {
+            padding-left: 20px;
+        }
+
+        .poetry2 {
+            padding-left: 40px;
+        }
+
+        .poetry3 {
+            padding-left: 60px;
+        }
+
+        .poetry4 {
+            padding-left: 80px;
+        }
+
+        .poetry5 {
+            padding-left: 100px;
+        }
+
+        .poetry6 {
+            padding-left: 120px;
+        }
+
 	</style>
 
 	<template>

--- a/src/js/render.js
+++ b/src/js/render.js
@@ -119,9 +119,35 @@ function Renderer() {
             return container.innerHTML;
         },
 
+        renderPoetry: function (text, module) {
+            const bExpression = new RegExp(/\\b/)
+            const qExpression = new RegExp(/\\q(\d+)?([^<]*)/);
+
+            while (bExpression.test(text)) {
+                text = text.replace(bExpression, "<br/>");
+            }
+
+            while (qExpression.test(text)) {
+                const match = qExpression.exec(text);
+                let level = match[1] || "1";
+                const content = match[2] || "";
+
+                if (parseInt(level) > 6) level = "6"
+
+                const div = document.createElement('div');
+                div.className = `style-scope poetry${level} ${module}`;
+                div.innerHTML = content;
+
+                text = text.replace(qExpression, div.outerHTML);
+            }
+
+            return text;
+        },
+
         renderTargetWithVerses: function (text, module) {
             text = this.replaceParagraphs(text);
             text = this.renderParagraphs(text, module);
+            text = this.renderPoetry(text, module);
             text = this.renderSuperscriptVerses(text);
 
             return text;
@@ -256,25 +282,8 @@ function Renderer() {
         renderPrintPreview: function (chunks, options, pagetitle) {
             const mythis = this;
             const module = "ts-print";
-            const startheader = "\<h2 class='style-scope " + module + "'\>";
-            const endheader = "\<\/h2\>";
-            let add = "";
-            if (options.doubleSpace) {
-                add += "double ";
-            }
-            if (options.justify) {
-                add += "justify ";
-            }
-            if (options.newpage) {
-                add += "break ";
-            }
-            const startdiv = "\<div class='style-scope " + add + module + "'\>";
-            const enddiv = "\<\/div\>";
+
             const chapters = [];
-
-            pagetitle = options.pagetitle ? "\<div class='style-scope page-title centered " + module + "' \>" + pagetitle + "\<\/div\>" : "";
-            let text = "\<div id='startnum' class='style-scope " + module + "'\>";
-
             _.forEach(_.groupBy(chunks, function(chunk) {
                 return chunk.chunkmeta.chapter;
             }), function (data, chap) {
@@ -283,6 +292,7 @@ function Renderer() {
 
                 _.forEach(data, function (chunk) {
                     if (chunk.chunkmeta.frameid === "title") {
+                        // Use transcontent if available, otherwise srccontent
                         title = chunk.transcontent || chunk.srccontent;
                     }
                     if (chunk.chunkmeta.frame > 0 && chunk.transcontent) {
@@ -297,19 +307,61 @@ function Renderer() {
                 }
             });
 
-            chapters.forEach(function (chapter) {
-                if (chapter.content) {
-                    if (options.newpage) {
-                        text += pagetitle;
-                    }
-                    text += startheader + chapter.title + endheader;
-                    text += startdiv + mythis.renderTargetWithVerses(chapter.content, module) + enddiv;
+            function createScopedElement(tag, extraClasses = []) {
+                const el = document.createElement(tag);
+                // Add default 'style-scope' and module class
+                el.classList.add("style-scope", module);
+                if (extraClasses.length > 0) {
+                    el.classList.add(...extraClasses);
                 }
+                return el;
+            }
+
+            function createPageTitleEl() {
+                const el = createScopedElement("div", ["page-title", "centered"]);
+                el.textContent = pagetitle || "";
+                return el;
+            }
+
+            const fragment = document.createDocumentFragment();
+
+            // If not in 'newpage' mode, the title sits outside the main container
+            if (!options.newpage && options.pagetitle) {
+                fragment.appendChild(createPageTitleEl());
+            }
+
+            const startNumDiv = createScopedElement("div");
+            startNumDiv.id = "startnum";
+
+            chapters.forEach(function (chapter) {
+                if (!chapter.content) return;
+
+                // If 'newpage' is on, title repeats inside the container before every chapter
+                if (options.newpage && options.pagetitle) {
+                    startNumDiv.appendChild(createPageTitleEl());
+                }
+
+                const header = createScopedElement("h2");
+                // Using innerHTML allows formatting within titles if necessary
+                header.innerHTML = chapter.title;
+                startNumDiv.appendChild(header);
+
+                const contentClasses = [];
+                if (options.doubleSpace) contentClasses.push("double");
+                if (options.justify) contentClasses.push("justify");
+                if (options.newpage) contentClasses.push("break");
+
+                const contentDiv = createScopedElement("div", contentClasses);
+
+                // Render verses content
+                contentDiv.innerHTML = mythis.renderTargetWithVerses(chapter.content, module);
+
+                startNumDiv.appendChild(contentDiv);
             });
 
-            const title = !options.newpage ? pagetitle : "";
+            fragment.appendChild(startNumDiv);
 
-            return title + text + enddiv;
+            return fragment.firstChild.outerHTML;
         },
 
         renderObsPrintPreview: function (chunks, options, imagePath) {
@@ -503,6 +555,7 @@ function Renderer() {
 
                     for (let i = 0; i < wordarray.length; i++) {
                         if (wordarray[i] === "\\v") {
+                            // Verse marker
                             const verse = parseInt(wordarray[i + 1]);
                             if (verses.indexOf(verse) >= 0 && used.indexOf(verse) === -1) {
                                 const marker = document.createElement("ts-verse-marker");
@@ -516,6 +569,7 @@ function Renderer() {
                             }
                             i++;
                         } else if (wordarray[i] === "\\f") {
+                            // Footnote marker
                             let footnote = "";
 
                             for (let k = i; k < wordarray.length; k++) {
@@ -536,7 +590,21 @@ function Renderer() {
                             }
 
                             noteindex++;
+                        } else if ((/\\q(\d+)?/.test(wordarray[i]))) {
+                            // Poetry marker
+                            const match = wordarray[i].match(/\\q(\d+)?/);
+                            let level = match[1] || "1";
+                            if (parseInt(level) > 6) level = "6";
+
+                            const span = document.createElement("span");
+                            span.className = `targets style-scope poetry${level} ${module}`;
+                            lineDiv.appendChild(span);
+                        } else if (wordarray[i] === "\\b") {
+                            // Poetry blank line
+                            const br = document.createElement("br");
+                            lineDiv.appendChild(br);
                         } else {
+                            // All the rest text and markers
                             const span = document.createElement("span");
                             span.className = `targets style-scope ${module}`;
                             span.textContent = wordarray[i];


### PR DESCRIPTION
Fixes #267.

Changes in this pull request:
- Render poetry markers (\q#) in output PDF
- Render poetry markers (\q#) in chunk previews