### PR TITLE
Jdw debupdate

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -205,6 +205,9 @@ function release(done){
             categories: [
                 "Translation", "Languages"
             ],
+            depends: [
+                "git"
+            ]
         }
         return debInstaller(options);
     }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -207,7 +207,9 @@ function release(done){
             ],
             depends: [
                 "git"
-            ]
+            ],
+            maintainer: "<wycliffeassociates.org>",
+            homepage: "https://bibletranslationtools.org/writer"
         }
         return debInstaller(options);
     }


### PR DESCRIPTION
Updated gulpfile for deb package creation.

Changes in this pull request:

- Updated gulpfile to require git as a dependency in deb package
- Updated gulpfile to list <wycliffeassociates.org> as the maintainer (matching Orature) in dep package
- Updated gulpfile to list "https://bibletranslationtools.org/writer" as the homepage of the deb package