### PR TITLE
Updated usfmtools lib that introduced the renderer that allows to fine-tune output usfm.

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "tar": "2.2.2",
     "trash": "7.2.0",
     "untildify": "2.1.0",
-    "usfmtools": "^1.1.0"
+    "usfmtools": "^1.2.0"
   },
   "devDependencies": {
     "@electron/packager": "^18.3.6",

--- a/src/js/importer.js
+++ b/src/js/importer.js
@@ -6,7 +6,12 @@ const AdmZip = require('adm-zip');
 const fs = require('fs');
 const readline = require('readline');
 const utils = require('../js/lib/utils');
-const {USFMParser, HMarker, CLMarker, CMarker, VMarker} = require("usfmtools");
+const {USFMParser, USFMRenderer, HMarker, CLMarker, CMarker, VMarker} = require("usfmtools");
+
+const chunkRenderer = new USFMRenderer({
+    unwrapWordEntries: true,
+    excludeMarkers: ["s"]
+});
 
 function ImportManager(configurator, migrator, dataManager, translate) {
 
@@ -136,7 +141,7 @@ function ImportManager(configurator, migrator, dataManager, translate) {
                             const verses = chapterObj.getChildMarkers(VMarker);
                             let transContent = _.chain(verses).filter(function (verse) {
                                 return verse.endingVerse <= last && verse.startingVerse >= first;
-                            }).map(v => v.getRawContents()).value().join(" ");
+                            }).map(v => chunkRenderer.render(v)).value().join(" ");
 
                             if (verses.length > 0 && first === 1) {
                                 // Retrieve markers that precede the first verse marker
@@ -146,7 +151,7 @@ function ImportManager(configurator, migrator, dataManager, translate) {
                                 for (const marker of siblingsBefore) {
                                     if (marker instanceof CMarker) continue;
                                     if (marker instanceof CLMarker) continue;
-                                    contentsBefore += marker.getRawContents()
+                                    contentsBefore += chunkRenderer.render(marker)
                                 }
                                 transContent = contentsBefore + transContent;
                             }


### PR DESCRIPTION
https://github.com/Bible-Translation-Tools/usfmtools-js/pull/3

Fixes #347.

Changes in this pull request:
- Strip strong's tags leaving only terms in place